### PR TITLE
docs: fix installation clone path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Rect Words is a cutting-edge, cross-platform reading application that transforms
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/your_username/rect-words.git
-   cd rect-words
+   git clone https://github.com/Wordsline/Wordsline.git
+   cd Wordsline
    ```
 
 2. **Install dependencies**


### PR DESCRIPTION
## Summary
- replace placeholder repo in README install steps with actual Wordsline path

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68957ebd99ac83218beaadff96f81b6f