### PR TITLE
Escape regex characters when highlighting words

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -30,9 +30,15 @@ export const cleanWord = (word) => {
   return word.toLowerCase().replace(/[^a-z]/g, '');
 };
 
+// Escape special characters for use in regular expressions
+export const escapeRegExp = (string) => {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
+
 export const highlightWordInText = (text, word) => {
-  const regex = new RegExp(`\\b${word}\\b`, 'gi');
-  return text.replace(regex, (match) => 
+  const escapedWord = escapeRegExp(word);
+  const regex = new RegExp(`\\b${escapedWord}\\b`, 'gi');
+  return text.replace(regex, (match) =>
     `<strong class="text-indigo-600 dark:text-indigo-400">${match}</strong>`
   );
 };


### PR DESCRIPTION
## Summary
- add `escapeRegExp` helper to sanitize input for regex construction
- use escaped word when highlighting text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68957ec129dc832197a0405dc0575a67